### PR TITLE
Fix "Data Missing" exception

### DIFF
--- a/app/Filters/UserFilter.php
+++ b/app/Filters/UserFilter.php
@@ -56,6 +56,9 @@ class UserFilter extends QueryFilter
 
     public function from($query, $date)
     {
+    	if(empty($date))
+            return;
+
         $date = Carbon::createFromFormat('d/m/Y', $date);
 
         $query->whereDate('created_at', '>=', $date);
@@ -63,6 +66,9 @@ class UserFilter extends QueryFilter
 
     public function to($query, $date)
     {
+    	if(empty($date))
+            return;
+        
         $date = Carbon::createFromFormat('d/m/Y', $date);
 
         $query->whereDate('created_at', '<=', $date);


### PR DESCRIPTION
This PR fix the "Data Missing" exception when the user delete the from_date and to_date filter values